### PR TITLE
Add depot removal, MQTT updates, and UI improvements

### DIFF
--- a/Controls/ColonizationCard.xaml
+++ b/Controls/ColonizationCard.xaml
@@ -97,6 +97,12 @@
         Visibility="{Binding IsInMainWindow, Converter={StaticResource BoolToVis}}">
                 <materialDesign:PackIcon Kind="OpenInNew" Width="20" Height="20" />
             </Button>
+            <Button Style="{DynamicResource MaterialDesignFlatButton}"
+        Command="{Binding RemoveCurrentDepotCommand}" 
+        ToolTip="Remove current colonization depot"
+        Margin="3,0">
+                <materialDesign:PackIcon Kind="Delete" Width="20" Height="20" />
+            </Button>
         </StackPanel>
 
         <!-- Overall Progress -->

--- a/Core/GameStateService.cs
+++ b/Core/GameStateService.cs
@@ -3192,6 +3192,11 @@ namespace EliteInfoPanel.Core
                 }
 
                 var json = File.ReadAllText(ColonizationDataFile);
+                if (string.IsNullOrWhiteSpace(json))
+                {
+                    Log.Debug("Colonization data file is empty or whitespace at {File}", ColonizationDataFile);
+                    return;
+                }
                 var loadedDepots = JsonSerializer.Deserialize<Dictionary<long, ColonizationData>>(json);
 
                 if (loadedDepots != null)

--- a/Core/GameStateService.cs
+++ b/Core/GameStateService.cs
@@ -503,7 +503,45 @@ namespace EliteInfoPanel.Core
         #endregion Public Properties
 
         #region Public Methods
+        /// <summary>
+        /// Removes a colonization depot from tracking
+        /// </summary>
+        public void RemoveColonizationDepot(long marketId)
+        {
+            try
+            {
+                Log.Information("📋 Removing colonization depot {MarketID}", marketId);
 
+                if (!_colonizationDepots.ContainsKey(marketId))
+                {
+                    Log.Warning("Depot {MarketID} not found in colonization depots", marketId);
+                    return;
+                }
+
+                // Remove from dictionary
+                _colonizationDepots.Remove(marketId);
+
+                // If this was the selected depot, select another or clear selection
+                if (_selectedDepotMarketId == marketId)
+                {
+                    _selectedDepotMarketId = _colonizationDepots.Keys.FirstOrDefault();
+                    OnPropertyChanged(nameof(SelectedColonizationDepot));
+                }
+
+                // Notify UI
+                OnPropertyChanged(nameof(ColonizationDepots));
+                OnPropertyChanged(nameof(CurrentColonization));
+
+                // Save to disk
+                SaveAllColonizationData();
+
+                Log.Information("✅ Colonization depot {MarketID} removed successfully", marketId);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Error removing colonization depot {MarketID}", marketId);
+            }
+        }
         public void BatchUpdate(Action updateAction)
         {
             using (BeginUpdate())
@@ -1638,6 +1676,33 @@ namespace EliteInfoPanel.Core
                                         {
                                             colonizationData.ConstructionFailed = failedProp.GetBoolean();
                                         }
+
+                                        // *** NEW: Check if construction is complete or failed - if so, remove it ***
+                                        if (colonizationData.ConstructionComplete || colonizationData.ConstructionFailed)
+                                        {
+                                            string status = colonizationData.ConstructionComplete ? "completed" : "failed";
+                                            Log.Information("📋 Colonization {Status} for depot {MarketID} - removing from tracking",
+                                                status, colonizationData.MarketID);
+
+                                            // Remove the depot if it exists
+                                            if (_colonizationDepots.ContainsKey(colonizationData.MarketID))
+                                            {
+                                                RemoveColonizationDepot(colonizationData.MarketID);
+                                            }
+
+                                            // Publish MQTT deletion (add this to MqttService if it doesn't exist)
+                                            try
+                                            {
+                                                await MqttService.Instance.PublishColonizationDepotDeletedAsync(colonizationData.MarketID);
+                                            }
+                                            catch (Exception mqttEx)
+                                            {
+                                                Log.Warning(mqttEx, "Could not publish MQTT deletion for depot {MarketID}", colonizationData.MarketID);
+                                            }
+
+                                            break; // Exit early since we removed it
+                                        }
+                                        // *** END NEW CODE ***
 
                                         colonizationData.ResourcesRequired = new List<ColonizationResource>();
 
@@ -3122,34 +3187,53 @@ namespace EliteInfoPanel.Core
             {
                 if (!File.Exists(ColonizationDataFile))
                 {
-                    Log.Information("No persisted colonization data file found");
+                    Log.Debug("No colonization data file found at {File}", ColonizationDataFile);
                     return;
                 }
 
-                string json = File.ReadAllText(ColonizationDataFile);
-                if (string.IsNullOrWhiteSpace(json))
+                var json = File.ReadAllText(ColonizationDataFile);
+                var loadedDepots = JsonSerializer.Deserialize<Dictionary<long, ColonizationData>>(json);
+
+                if (loadedDepots != null)
                 {
-                    Log.Warning("Colonization data file is empty");
-                    return;
+                    _colonizationDepots.Clear();
+
+                    // **CRITICAL FIX: Only load depots that are NOT complete or failed**
+                    int skippedCount = 0;
+                    foreach (var depot in loadedDepots.Values)
+                    {
+                        if (!depot.ConstructionComplete && !depot.ConstructionFailed)
+                        {
+                            _colonizationDepots[depot.MarketID] = depot;
+                        }
+                        else
+                        {
+                            skippedCount++;
+                            Log.Information("Skipping completed/failed depot {MarketID} during load (Complete: {Complete}, Failed: {Failed})",
+                                depot.MarketID, depot.ConstructionComplete, depot.ConstructionFailed);
+                        }
+                    }
+
+                    Log.Information("Loaded {Count} active colonization depots (skipped {Skipped} completed/failed)",
+                        _colonizationDepots.Count, skippedCount);
+
+                    // Select first depot if none selected and depots exist
+                    if (_colonizationDepots.Any())
+                    {
+                        if (!_selectedDepotMarketId.HasValue || !_colonizationDepots.ContainsKey(_selectedDepotMarketId.Value))
+                        {
+                            _selectedDepotMarketId = _colonizationDepots.Keys.First();
+                        }
+                    }
+                    else
+                    {
+                        _selectedDepotMarketId = null;
+                    }
+
+                    OnPropertyChanged(nameof(ColonizationDepots));
+                    OnPropertyChanged(nameof(CurrentColonization));
+                    OnPropertyChanged(nameof(SelectedColonizationDepot));
                 }
-
-                var depots = JsonSerializer.Deserialize<List<ColonizationData>>(json);
-                if (depots == null || !depots.Any())
-                {
-                    Log.Warning("No colonization depots found in file");
-                    return;
-                }
-
-                _colonizationDepots.Clear();
-                foreach (var depot in depots.Where(d => !d.ConstructionComplete && !d.ConstructionFailed))
-                {
-                    _colonizationDepots[depot.MarketID] = depot;
-                }
-
-                // Select first depot
-                _selectedDepotMarketId = _colonizationDepots.Keys.FirstOrDefault();
-
-                Log.Information("Loaded {Count} active colonization depots from file", _colonizationDepots.Count);
             }
             catch (Exception ex)
             {

--- a/Services/MqttService.cs
+++ b/Services/MqttService.cs
@@ -16,29 +16,172 @@ namespace EliteInfoPanel.Services
 {
     public class MqttService : IDisposable
     {
-        private static readonly Lazy<MqttService> _instance = new Lazy<MqttService>(() => new MqttService());
-        public static MqttService Instance => _instance.Value;
+        #region Private Fields
 
-        private readonly HashSet<string> _haConfigSent = new(); // Track sent configs
-        private IMqttClient _mqttClient;
-        private AppSettings _settings;
+        private static readonly Lazy<MqttService> _instance = new Lazy<MqttService>(() => new MqttService());
+        private readonly HashSet<string> _haConfigSent = new();
         private readonly object _lockObject = new object();
-        private DateTime _lastPublish = DateTime.MinValue;
-        private Dictionary<Flag, bool> _lastFlagStates = new Dictionary<Flag, bool>();
-        private Dictionary<Flags2, bool> _lastFlags2States = new Dictionary<Flags2, bool>();
-        private bool _isInitialized = false;
         private readonly Timer _reconnectTimer;
         private CancellationTokenSource _cancellationTokenSource;
+        private bool _isInitialized = false;
+        private Dictionary<Flags2, bool> _lastFlags2States = new Dictionary<Flags2, bool>();
+        private Dictionary<Flag, bool> _lastFlagStates = new Dictionary<Flag, bool>();
+        private DateTime _lastPublish = DateTime.MinValue;
+        // Track sent configs
+        private IMqttClient _mqttClient;
+
+        private AppSettings _settings;
         private string deviceName = "eliteinfopanel";
 
-        public bool IsConnected => _mqttClient?.IsConnected ?? false;
-        public event EventHandler<bool> ConnectionStateChanged;
+        #endregion Private Fields
+
+        #region Private Constructors
 
         private MqttService()
         {
             _cancellationTokenSource = new CancellationTokenSource();
             // Initialize reconnect timer (check every 30 seconds)
             _reconnectTimer = new Timer(CheckConnection, null, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(30));
+        }
+
+        #endregion Private Constructors
+
+        #region Public Events
+
+        public event EventHandler<bool> ConnectionStateChanged;
+
+        #endregion Public Events
+
+        #region Public Properties
+
+        public static MqttService Instance => _instance.Value;
+        public bool IsConnected => _mqttClient?.IsConnected ?? false;
+
+        #endregion Public Properties
+
+        #region Public Methods
+
+        public async Task ClearAllHomeAssistantEntities()
+        {
+            if (!_settings.MqttEnabled || _mqttClient == null || !_mqttClient.IsConnected)
+                return;
+
+            try
+            {
+                // Publish empty payloads to remove all existing configs
+                foreach (var configTopic in _haConfigSent.ToList())
+                {
+                    await PublishAsync(configTopic, "", retain: true);
+                    Log.Debug("Cleared Home Assistant config: {Topic}", configTopic);
+                }
+
+                // Clear the sent configs cache
+                _haConfigSent.Clear();
+
+                // Wait a moment for Home Assistant to process
+                await Task.Delay(2000);
+
+                // Force republish all current states
+                await ForceReconfigureHomeAssistant();
+
+                Log.Information("Cleared and reconfigured all Home Assistant entities");
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Error clearing Home Assistant entities");
+            }
+        }
+
+        public async Task ClearHomeAssistantConfigs()
+        {
+            _haConfigSent.Clear();
+            Log.Information("Cleared Home Assistant configuration cache - configs will be resent on next publish");
+        }
+
+        public async Task DisconnectAsync()
+        {
+            if (_mqttClient != null && _mqttClient.IsConnected)
+            {
+                try
+                {
+                    await _mqttClient.DisconnectAsync(MqttClientDisconnectOptionsReason.NormalDisconnection);
+                    Log.Information("MQTT client disconnected");
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, "Error disconnecting MQTT client");
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            _cancellationTokenSource?.Cancel();
+            _reconnectTimer?.Dispose();
+
+            if (_mqttClient != null)
+            {
+                try
+                {
+                    if (_mqttClient.IsConnected)
+                    {
+                        _mqttClient.DisconnectAsync(MqttClientDisconnectOptionsReason.NormalDisconnection).Wait(5000);
+                    }
+                    _mqttClient.Dispose();
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, "Error disposing MQTT client");
+                }
+            }
+
+            _cancellationTokenSource?.Dispose();
+        }
+
+        public async Task ForceReconfigureHomeAssistant()
+        {
+            if (!_settings.MqttEnabled || _mqttClient == null || !_mqttClient.IsConnected)
+                return;
+
+            try
+            {
+                // Clear the cache so configs get resent
+                _haConfigSent.Clear();
+
+                // If we have current states, republish them to trigger config resend
+                if (_lastFlagStates.Any() || _lastFlags2States.Any())
+                {
+                    var tasks = new List<Task>();
+
+                    // Republish all flag configs and states using consistent topic structure
+                    foreach (var kvp in _lastFlagStates)
+                    {
+                        string sensor = kvp.Key.ToString().ToLowerInvariant();
+                        string stateTopic = $"{_settings.MqttTopicPrefix}/binary_sensor/{deviceName}/{sensor}/state";
+
+                        await PublishHomeAssistantConfigIfNeeded(kvp.Key.ToString(), stateTopic, "flag");
+                        tasks.Add(PublishAsync(stateTopic, kvp.Value ? "ON" : "OFF", retain: _settings.MqttRetainMessages));
+                    }
+
+                    // Use same topic structure for flags2
+                    foreach (var kvp in _lastFlags2States)
+                    {
+                        string sensor = kvp.Key.ToString().ToLowerInvariant();
+                        string stateTopic = $"{_settings.MqttTopicPrefix}/binary_sensor/{deviceName}/{sensor}/state";
+
+                        await PublishHomeAssistantConfigIfNeeded(kvp.Key.ToString(), stateTopic, "flags2");
+                        tasks.Add(PublishAsync(stateTopic, kvp.Value ? "ON" : "OFF", retain: _settings.MqttRetainMessages));
+                    }
+
+                    await Task.WhenAll(tasks);
+                    Log.Information("Force reconfigured Home Assistant with {FlagCount} flags and {Flags2Count} flags2",
+                        _lastFlagStates.Count, _lastFlags2States.Count);
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Error force reconfiguring Home Assistant");
+            }
         }
 
         public async Task InitializeAsync(AppSettings settings)
@@ -72,457 +215,6 @@ namespace EliteInfoPanel.Services
             }
         }
 
-        private async Task SetupMqttClientAsync()
-        {
-            // Dispose existing client if it exists
-            if (_mqttClient != null)
-            {
-                if (_mqttClient.IsConnected)
-                {
-                    await _mqttClient.DisconnectAsync(MqttClientDisconnectOptionsReason.NormalDisconnection);
-                }
-                _mqttClient.Dispose();
-            }
-
-            var factory = new MqttClientFactory();
-            _mqttClient = factory.CreateMqttClient();
-
-            // Create client options using MQTTnet 5 API
-            var clientOptionsBuilder = new MqttClientOptionsBuilder()
-                .WithClientId(_settings.MqttClientId)
-                .WithTcpServer(_settings.MqttBrokerHost, _settings.MqttBrokerPort)
-                .WithCleanSession(true)
-                .WithProtocolVersion(MqttProtocolVersion.V500);
-
-            // Add credentials if provided
-            if (!string.IsNullOrEmpty(_settings.MqttUsername))
-            {
-                clientOptionsBuilder.WithCredentials(_settings.MqttUsername, _settings.MqttPassword);
-            }
-
-            // Add TLS if enabled
-            if (_settings.MqttUseTls)
-            {
-                clientOptionsBuilder.WithTlsOptions(o =>
-                {
-                    o.UseTls();
-                    o.WithAllowUntrustedCertificates(false);
-                    o.WithIgnoreCertificateChainErrors(false);
-                    o.WithIgnoreCertificateRevocationErrors(false);
-                });
-            }
-
-            var clientOptions = clientOptionsBuilder.Build();
-
-            // Set up event handlers
-            _mqttClient.ConnectedAsync += OnConnectedAsync;
-            _mqttClient.DisconnectedAsync += OnDisconnectedAsync;
-
-            // Connect the client
-            await _mqttClient.ConnectAsync(clientOptions, _cancellationTokenSource.Token);
-        }
-
-        private Task OnConnectedAsync(MqttClientConnectedEventArgs arg)
-        {
-            Log.Information("MQTT client connected to {Host}:{Port}", _settings.MqttBrokerHost, _settings.MqttBrokerPort);
-            ConnectionStateChanged?.Invoke(this, true);
-            return Task.CompletedTask;
-        }
-
-        private Task OnDisconnectedAsync(MqttClientDisconnectedEventArgs arg)
-        {
-            Log.Warning("MQTT client disconnected: {Reason}", arg.Reason);
-            ConnectionStateChanged?.Invoke(this, false);
-
-            // Auto-reconnect if not a normal disconnection
-            if (arg.Reason != MqttClientDisconnectReason.NormalDisconnection &&
-                _settings?.MqttEnabled == true && !_cancellationTokenSource.IsCancellationRequested)
-            {
-                _ = Task.Run(async () =>
-                {
-                    await Task.Delay(TimeSpan.FromSeconds(5), _cancellationTokenSource.Token);
-                    if (!_cancellationTokenSource.IsCancellationRequested)
-                    {
-                        try
-                        {
-                            await SetupMqttClientAsync();
-                        }
-                        catch (Exception ex)
-                        {
-                            Log.Error(ex, "Failed to reconnect MQTT client");
-                        }
-                    }
-                });
-            }
-
-            return Task.CompletedTask;
-        }
-
-        public async Task PublishFlagStatesAsync(StatusJson status, bool? isDocking = null, bool forcePublish = false)
-        {
-            if (_settings == null)
-                return;
-            if (!_settings.MqttEnabled || _mqttClient == null || !_mqttClient.IsConnected || status == null)
-                return;
-
-            // Rate limiting (skip if not forcing and within rate limit)
-            if (!forcePublish && (DateTime.UtcNow - _lastPublish).TotalMilliseconds < _settings.MqttPublishIntervalMs)
-                return;
-
-            try
-            {
-                var currentFlags = GetCurrentFlagStates(status, isDocking);
-                var currentFlags2 = GetCurrentFlags2States(status);
-
-                // Check if we should publish (only on changes if configured, unless forced)
-                bool hasChanges = HasFlagChanges(currentFlags, currentFlags2);
-                if (!forcePublish && _settings.MqttPublishOnlyChanges && !hasChanges)
-                    return;
-
-                if (forcePublish || hasChanges)
-                {
-                    Log.Information("Publishing MQTT flags - Force={Force}, HasChanges={HasChanges}, ActiveFlags={ActiveFlags}",
-                        forcePublish, hasChanges, currentFlags.Count(f => f.Value));
-                }
-
-                // Publish individual flag states for Home Assistant
-                await PublishIndividualFlagsAsync(currentFlags, currentFlags2);
-
-                // Publish combined status with metadata
-                await PublishCombinedStatusAsync(status, currentFlags, currentFlags2);
-
-                // Update last states
-                _lastFlagStates = currentFlags;
-                _lastFlags2States = currentFlags2;
-                _lastPublish = DateTime.UtcNow;
-
-                Log.Debug("Published MQTT flag states: {ActiveFlags} active flags, {ActiveFlags2} active flags2",
-                    currentFlags.Count(f => f.Value), currentFlags2.Count(f => f.Value));
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Error publishing MQTT flag states");
-            }
-        }
-
-        private Dictionary<Flag, bool> GetCurrentFlagStates(StatusJson status, bool? isDocking = null)
-        {
-            var states = new Dictionary<Flag, bool>();
-
-            // Get ALL flags from the enum
-            foreach (Flag flag in Enum.GetValues<Flag>())
-            {
-                if (flag == Flag.None) continue;
-
-                // Handle synthetic flags specially
-                if (flag == SyntheticFlags.HudInCombatMode)
-                {
-                    states[flag] = !status.Flags.HasFlag(Flag.HudInAnalysisMode);
-                }
-                else if (flag == SyntheticFlags.Docking)
-                {
-                    // Docking should be true only when actively docking, false when docked or not docking
-                    bool dockingState = isDocking ?? false;
-                    states[flag] = dockingState;
-                    Log.Debug("Synthetic Docking flag: isDocking={IsDocking}, result={Result}", isDocking, dockingState);
-                }
-                else
-                {
-                    states[flag] = status.Flags.HasFlag(flag);
-                }
-            }
-
-            // Add debug logging for key states
-            Log.Debug("Flag states: Docked={Docked}, Docking={Docking}, IsDockingParam={IsDockingParam}",
-                states.GetValueOrDefault(Flag.Docked),
-                states.GetValueOrDefault(SyntheticFlags.Docking),
-                isDocking);
-
-            return states;
-        }
-
-        private Dictionary<Flags2, bool> GetCurrentFlags2States(StatusJson status)
-        {
-            var states = new Dictionary<Flags2, bool>();
-
-            // Get ALL flags2 from the enum
-            foreach (Flags2 flag in Enum.GetValues<Flags2>())
-            {
-                if (flag == Flags2.None) continue;
-                states[flag] = (status.Flags2 & (int)flag) != 0;
-            }
-
-            return states;
-        }
-
-        private bool HasFlagChanges(Dictionary<Flag, bool> currentFlags, Dictionary<Flags2, bool> currentFlags2)
-        {
-            // Check if any primary flags changed
-            foreach (var kvp in currentFlags)
-            {
-                if (!_lastFlagStates.TryGetValue(kvp.Key, out bool lastState) || lastState != kvp.Value)
-                {
-                    Log.Debug("Flag {Flag} changed: {OldState} -> {NewState}", kvp.Key, lastState, kvp.Value);
-                    return true;
-                }
-            }
-
-            // Check if any Flags2 changed
-            foreach (var kvp in currentFlags2)
-            {
-                if (!_lastFlags2States.TryGetValue(kvp.Key, out bool lastState) || lastState != kvp.Value)
-                {
-                    Log.Debug("Flags2 {Flag} changed: {OldState} -> {NewState}", kvp.Key, lastState, kvp.Value);
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        private async Task PublishHomeAssistantConfigIfNeeded(string flagName, string stateTopic, string flagType = "flag")
-        {
-            if (!_settings.MqttEnabled || _mqttClient == null || !_mqttClient.IsConnected)
-                return;
-
-            string sensor = flagName.ToLowerInvariant();
-            // Change the config topic to not include the device name prefix
-            string configTopic = $"homeassistant/binary_sensor/eliteinfopanel/{sensor}/config";
-
-            if (_haConfigSent.Contains(configTopic)) return;
-
-            // Get metadata for this flag
-            string icon = "mdi:help";
-            string friendlyName = flagName;
-
-            if (flagType == "flag" && Enum.TryParse<Flag>(flagName, true, out var flag))
-            {
-                if (FlagVisualHelper.TryGetMetadata(flag, out var metadata))
-                {
-                    icon = $"mdi:{metadata.Icon.ToLowerInvariant()}";
-                    friendlyName = metadata.Tooltip ?? flagName;
-                }
-            }
-            else if (flagType == "flags2" && Enum.TryParse<Flags2>(flagName, true, out var flags2))
-            {
-                if (Flags2VisualHelper.TryGetMetadata(flags2, out var metadata))
-                {
-                    icon = $"mdi:{metadata.Icon.ToLowerInvariant()}";
-                    friendlyName = metadata.Tooltip ?? flagName;
-                }
-            }
-
-            var configPayload = new
-            {
-                name = friendlyName, // Use just the friendly name without device prefix
-                state_topic = stateTopic,
-                unique_id = $"eliteinfopanel_{sensor}", // Keep unique ID with prefix for uniqueness
-                object_id = sensor, // Add this to control the entity ID
-                icon = icon,
-                payload_on = "ON",
-                payload_off = "OFF",
-                device_class = GetDeviceClass(flagName),
-                device = new
-                {
-                    identifiers = new[] { "eliteinfopanel" }, // Consistent device identifier
-                    name = "Elite Info Panel", // More readable device name
-                    manufacturer = "Frontier Developments",
-                    model = "Elite Dangerous Game State",
-                    sw_version = "1.0"
-                }
-            };
-
-            string configJson = JsonSerializer.Serialize(configPayload);
-            await PublishAsync(configTopic, configJson, retain: true);
-            _haConfigSent.Add(configTopic);
-
-            Log.Debug("Published Home Assistant config for {FlagType} {Flag}: {FriendlyName}", flagType, flagName, friendlyName);
-        }
-       
-
-        public async Task ClearAllHomeAssistantEntities()
-        {
-            if (!_settings.MqttEnabled || _mqttClient == null || !_mqttClient.IsConnected)
-                return;
-
-            try
-            {
-                // Publish empty payloads to remove all existing configs
-                foreach (var configTopic in _haConfigSent.ToList())
-                {
-                    await PublishAsync(configTopic, "", retain: true);
-                    Log.Debug("Cleared Home Assistant config: {Topic}", configTopic);
-                }
-
-                // Clear the sent configs cache
-                _haConfigSent.Clear();
-
-                // Wait a moment for Home Assistant to process
-                await Task.Delay(2000);
-
-                // Force republish all current states
-                await ForceReconfigureHomeAssistant();
-
-                Log.Information("Cleared and reconfigured all Home Assistant entities");
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Error clearing Home Assistant entities");
-            }
-        }
-        private string GetDeviceClass(string flagName)
-        {
-            // Be more conservative with device classes to avoid "Connected" states
-            return flagName.ToLower() switch
-            {
-                "overheating" => "problem",
-                "lowfuel" => "problem",
-                "isindanger" => "problem",
-                "beinginterdicted" => "problem",
-                "constructionfailed" => "problem",
-                "constructioncomplete" => null, // Let it default to on/off
-                "supercruise" => "motion",
-                "fsdcharging" => "motion",
-                "fsdjump" => "motion",
-                "glidemode" => "motion",
-                _ => null // Default to no device class for most flags to ensure On/Off display
-            };
-        }
-
-        private async Task PublishIndividualFlagsAsync(Dictionary<Flag, bool> flags, Dictionary<Flags2, bool> flags2)
-        {
-            var tasks = new List<Task>();
-
-            // Publish ALL primary flags as Home Assistant binary sensors
-            foreach (var kvp in flags)
-            {
-                string sensor = kvp.Key.ToString().ToLowerInvariant();
-                // Use consistent topic structure for all sensors
-                string stateTopic = $"{_settings.MqttTopicPrefix}/binary_sensor/{deviceName}/{sensor}/state";
-                string payload = kvp.Value ? "ON" : "OFF";
-
-                // Send Home Assistant config first
-                await PublishHomeAssistantConfigIfNeeded(kvp.Key.ToString(), stateTopic, "flag");
-
-                // Then send the state
-                tasks.Add(PublishAsync(stateTopic, payload, retain: _settings.MqttRetainMessages));
-            }
-
-            // Publish ALL Flags2 as Home Assistant binary sensors using the same topic structure
-            foreach (var kvp in flags2)
-            {
-                string sensor = kvp.Key.ToString().ToLowerInvariant();
-                // Use same topic structure as primary flags to keep under one device
-                string stateTopic = $"{_settings.MqttTopicPrefix}/binary_sensor/{deviceName}/{sensor}/state";
-                string payload = kvp.Value ? "ON" : "OFF";
-
-                // Send Home Assistant config first
-                await PublishHomeAssistantConfigIfNeeded(kvp.Key.ToString(), stateTopic, "flags2");
-
-                // Then send the state
-                tasks.Add(PublishAsync(stateTopic, payload, retain: _settings.MqttRetainMessages));
-            }
-
-            await Task.WhenAll(tasks);
-        }
-
-        private async Task PublishCombinedStatusAsync(StatusJson status, Dictionary<Flag, bool> flags, Dictionary<Flags2, bool> flags2)
-        {
-            var topic = $"{_settings.MqttTopicPrefix}/status";
-
-            // Enhanced combined status with metadata
-            var payload = JsonSerializer.Serialize(new
-            {
-                timestamp = DateTime.UtcNow.ToString("O"),
-                flags = flags.ToDictionary(
-                    f => f.Key.ToString().ToLower(),
-                    f => new {
-                        active = f.Value,
-                        metadata = FlagVisualHelper.TryGetMetadata(f.Key, out var meta) ? new
-                        {
-                            icon = meta.Icon,
-                            tooltip = meta.Tooltip,
-                            color = meta.Color.ToString()
-                        } : null
-                    }
-                ),
-                flags2 = flags2.ToDictionary(
-                    f => f.Key.ToString().ToLower(),
-                    f => new {
-                        active = f.Value,
-                        metadata = Flags2VisualHelper.TryGetMetadata(f.Key, out var meta) ? new
-                        {
-                            icon = meta.Icon,
-                            tooltip = meta.Tooltip,
-                            color = meta.Color.ToString()
-                        } : null
-                    }
-                ),
-                raw_flags = (uint)status.Flags,
-                raw_flags2 = status.Flags2,
-                fuel = status.Fuel?.FuelMain ?? 0,
-                balance = status.Balance,
-                on_foot = status.OnFoot,
-                active_flags_count = flags.Count(f => f.Value),
-                active_flags2_count = flags2.Count(f => f.Value),
-                total_flags_count = flags.Count,
-                total_flags2_count = flags2.Count
-            }, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
-
-            await PublishAsync(topic, payload, retain: _settings.MqttRetainMessages);
-        }
-
-        private async Task PublishAsync(string topic, string payload, bool retain = false)
-        {
-            if (_mqttClient == null || !_mqttClient.IsConnected)
-                return;
-
-            try
-            {
-                var applicationMessage = new MqttApplicationMessageBuilder()
-                    .WithTopic(topic)
-                    .WithPayload(payload)
-                    .WithQualityOfServiceLevel((MqttQualityOfServiceLevel)_settings.MqttQosLevel)
-                    .WithRetainFlag(retain)
-                    .Build();
-
-                await _mqttClient.PublishAsync(applicationMessage, _cancellationTokenSource.Token);
-                Log.Debug("Published MQTT message to {Topic}: {Payload}", topic, payload);
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Error publishing MQTT message to topic: {Topic}", topic);
-            }
-        }
-
-        public async Task PublishCommanderStatusAsync(string commanderName, string system, string ship, decimal credits, double fuel, double fuelreserve)
-        {
-            if (!_settings.MqttEnabled || _mqttClient == null || !_mqttClient.IsConnected)
-                return;
-
-            try
-            {
-                await PublishHomeAssistantCommanderConfigsIfNeeded();
-
-                var topic = $"{_settings.MqttTopicPrefix}/commander";
-                var payload = JsonSerializer.Serialize(new
-                {
-                    commander = commanderName,
-                    system,
-                    ship,
-                    credits,
-                    fuel,
-                    fuelreserve,
-                    timestamp = DateTime.UtcNow.ToString("O")
-                }, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
-
-                await PublishAsync(topic, payload, retain: _settings.MqttRetainMessages);
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Error publishing commander status to MQTT");
-            }
-        }
         public async Task PublishAllColonizationDepotsAsync(List<ColonizationData> activeDepots)
         {
             if (_settings == null)
@@ -592,10 +284,11 @@ namespace EliteInfoPanel.Services
                 Log.Error(ex, "Error publishing all colonization depots to MQTT");
             }
         }
+
         public async Task PublishColonizationDepotAsync(long marketId, double progress, bool complete, bool failed, List<ColonizationResource> resources)
         {
-            if(_settings == null)
-                return; 
+            if (_settings == null)
+                return;
             if (!_settings.MqttEnabled || _mqttClient == null || !_mqttClient.IsConnected)
                 return;
 
@@ -646,119 +339,129 @@ namespace EliteInfoPanel.Services
                 Log.Error(ex, "Error publishing colonization depot to MQTT");
             }
         }
-        private async Task PublishColonizationHomeAssistantDiscovery(long marketId)
+        /// <summary>
+        /// Publishes a deletion notification for a colonization depot and removes Home Assistant discovery configs
+        /// </summary>
+        public async Task PublishColonizationDepotDeletedAsync(long marketId)
         {
-            // Create Home Assistant discovery configs for this depot
-            var baseConfig = new
+            if (_settings == null)
+                return;
+            if (!_settings.MqttEnabled || _mqttClient == null || !_mqttClient.IsConnected)
+                return;
+
+            try
             {
-                device = new
+                // Publish a deletion event to a dedicated topic
+                string deletionTopic = $"{_settings.MqttTopicPrefix}/colonisation/deleted";
+                var deletionPayload = new
                 {
-                    identifiers = new[] { $"eliteinfopanel_colonisation_{marketId}" },
-                    name = $"Colonisation Depot {marketId}",
-                    manufacturer = "Frontier Developments",
-                    model = "Elite Dangerous Colonisation Depot",
-                    sw_version = "1.0"
-                },
-                availability = new
-                {
-                    topic = $"{_settings.MqttTopicPrefix}/status",
-                    payload_available = "online",
-                    payload_not_available = "offline"
-                }
-            };
-
-            // Progress sensor
-            var progressConfig = new
-            {
-                name = $"Colonisation Progress {marketId}",
-                state_topic = $"{_settings.MqttTopicPrefix}/colonisation/depots/{marketId}",
-                value_template = "{{ value_json.ConstructionProgress | float * 100 | round(1) }}",
-                unit_of_measurement = "%",
-                icon = "mdi:progress-clock",
-                unique_id = $"eliteinfopanel_colonisation_progress_{marketId}",
-                device = baseConfig.device
-            };
-
-            // Resources completed sensor
-            var resourcesConfig = new
-            {
-                name = $"Colonisation Resources {marketId}",
-                state_topic = $"{_settings.MqttTopicPrefix}/colonisation/depots/{marketId}",
-                value_template = "{{ value_json.ResourcesRequired | selectattr('IsComplete', 'equalto', true) | list | length }}",
-                unit_of_measurement = "resources",
-                icon = "mdi:package-check",
-                unique_id = $"eliteinfopanel_colonisation_resources_{marketId}",
-                device = baseConfig.device,
-                json_attributes_topic = $"{_settings.MqttTopicPrefix}/colonisation/depots/{marketId}",
-                json_attributes_template = "{{ {'total_resources': value_json.ResourcesRequired | length, 'resources': value_json.ResourcesRequired} | tojson }}"
-            };
-
-            // Status sensor (active/complete/failed)
-            var statusConfig = new
-            {
-                name = $"Colonisation Status {marketId}",
-                state_topic = $"{_settings.MqttTopicPrefix}/colonisation/depots/{marketId}",
-                value_template = "{% if value_json.ConstructionComplete %}complete{% elif value_json.ConstructionFailed %}failed{% else %}active{% endif %}",
-                icon = "mdi:home-city",
-                unique_id = $"eliteinfopanel_colonisation_status_{marketId}",
-                device = baseConfig.device
-            };
-
-            // Publish discovery configs
-            await PublishAsync($"homeassistant/sensor/eliteinfopanel_colonisation_progress_{marketId}/config",
-                JsonSerializer.Serialize(progressConfig), retain: true);
-
-            await PublishAsync($"homeassistant/sensor/eliteinfopanel_colonisation_resources_{marketId}/config",
-                JsonSerializer.Serialize(resourcesConfig), retain: true);
-
-            await PublishAsync($"homeassistant/sensor/eliteinfopanel_colonisation_status_{marketId}/config",
-                JsonSerializer.Serialize(statusConfig), retain: true);
-        }
-        private async Task PublishHomeAssistantCommanderConfigsIfNeeded()
-        {
-            string baseTopic = $"{_settings.MqttTopicPrefix}/commander";
-
-            var configs = new List<(string id, string name, string valueTemplate)>
-    {
-        ("commander", "Commander", "{{ value_json.commander }}"),
-        ("system", "System", "{{ value_json.system }}"),
-        ("ship", "Ship", "{{ value_json.ship }}"),
-        ("credits", "Credits", "{{ value_json.credits }}"),
-        ("fuel", "Fuel", "{{ value_json.fuel }}"),
-        ("fuelreserve", "Fuel Reserve", "{{ value_json.fuelreserve }}")
-    };
-
-            foreach (var (id, name, valueTemplate) in configs)
-            {
-                string configTopic = $"homeassistant/sensor/eliteinfopanel_{id}/config";
-                if (_haConfigSent.Contains(configTopic)) continue;
-
-                var configPayload = new
-                {
-                    name,
-                    state_topic = baseTopic,
-                    unique_id = $"eliteinfopanel_{id}",
-                    object_id = id,
-                    value_template = valueTemplate,
-                    json_attributes_topic = baseTopic,  // Optional, if you want other fields as attributes
-                    device = new
-                    {
-                        identifiers = new[] { "eliteinfopanel" },
-                        name = "Elite Info Panel",
-                        manufacturer = "Frontier Developments",
-                        model = "Elite Dangerous Game State",
-                        sw_version = "1.0"
-                    }
+                    MarketID = marketId,
+                    DeletedAt = DateTime.UtcNow.ToString("O"),
+                    Reason = "Removed by user or construction completed/failed"
                 };
 
-                string configJson = JsonSerializer.Serialize(configPayload);
-                await PublishAsync(configTopic, configJson, retain: true);
-                _haConfigSent.Add(configTopic);
+                await PublishAsync(deletionTopic, JsonSerializer.Serialize(deletionPayload), retain: false);
 
-                Log.Debug("Published Home Assistant config for {Name} sensor", name);
+                // Clear the depot-specific topic by publishing an empty message
+                string depotTopic = $"{_settings.MqttTopicPrefix}/colonisation/depots/{marketId}";
+                await PublishAsync(depotTopic, "", retain: true);
+
+                // Remove Home Assistant discovery configs by publishing empty payloads
+                var discoveryTopics = new[]
+                {
+            $"homeassistant/sensor/eliteinfopanel_colonisation_progress_{marketId}/config",
+            $"homeassistant/sensor/eliteinfopanel_colonisation_resources_{marketId}/config",
+            $"homeassistant/sensor/eliteinfopanel_colonisation_status_{marketId}/config"
+        };
+
+                foreach (var topic in discoveryTopics)
+                {
+                    await PublishAsync(topic, "", retain: true);
+                    Log.Debug("Removed Home Assistant config: {Topic}", topic);
+                }
+
+                Log.Information("MQTT: Published colonisation depot {MarketID} deletion and removed HA configs", marketId);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Error publishing colonization depot deletion to MQTT");
+            }
+        }
+        public async Task PublishCommanderStatusAsync(string commanderName, string system, string ship, decimal credits, double fuel, double fuelreserve)
+        {
+            if (!_settings.MqttEnabled || _mqttClient == null || !_mqttClient.IsConnected)
+                return;
+
+            try
+            {
+                await PublishHomeAssistantCommanderConfigsIfNeeded();
+
+                var topic = $"{_settings.MqttTopicPrefix}/commander";
+                var payload = JsonSerializer.Serialize(new
+                {
+                    commander = commanderName,
+                    system,
+                    ship,
+                    credits,
+                    fuel,
+                    fuelreserve,
+                    timestamp = DateTime.UtcNow.ToString("O")
+                }, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+
+                await PublishAsync(topic, payload, retain: _settings.MqttRetainMessages);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Error publishing commander status to MQTT");
             }
         }
 
+        public async Task PublishFlagStatesAsync(StatusJson status, bool? isDocking = null, bool forcePublish = false)
+        {
+            if (_settings == null)
+                return;
+            if (!_settings.MqttEnabled || _mqttClient == null || !_mqttClient.IsConnected || status == null)
+                return;
+
+            // Rate limiting (skip if not forcing and within rate limit)
+            if (!forcePublish && (DateTime.UtcNow - _lastPublish).TotalMilliseconds < _settings.MqttPublishIntervalMs)
+                return;
+
+            try
+            {
+                var currentFlags = GetCurrentFlagStates(status, isDocking);
+                var currentFlags2 = GetCurrentFlags2States(status);
+
+                // Check if we should publish (only on changes if configured, unless forced)
+                bool hasChanges = HasFlagChanges(currentFlags, currentFlags2);
+                if (!forcePublish && _settings.MqttPublishOnlyChanges && !hasChanges)
+                    return;
+
+                if (forcePublish || hasChanges)
+                {
+                    Log.Information("Publishing MQTT flags - Force={Force}, HasChanges={HasChanges}, ActiveFlags={ActiveFlags}",
+                        forcePublish, hasChanges, currentFlags.Count(f => f.Value));
+                }
+
+                // Publish individual flag states for Home Assistant
+                await PublishIndividualFlagsAsync(currentFlags, currentFlags2);
+
+                // Publish combined status with metadata
+                await PublishCombinedStatusAsync(status, currentFlags, currentFlags2);
+
+                // Update last states
+                _lastFlagStates = currentFlags;
+                _lastFlags2States = currentFlags2;
+                _lastPublish = DateTime.UtcNow;
+
+                Log.Debug("Published MQTT flag states: {ActiveFlags} active flags, {ActiveFlags2} active flags2",
+                    currentFlags.Count(f => f.Value), currentFlags2.Count(f => f.Value));
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Error publishing MQTT flag states");
+            }
+        }
 
         public async Task PublishGameEventAsync(string eventType, object eventData)
         {
@@ -836,21 +539,9 @@ namespace EliteInfoPanel.Services
             }
         }
 
-        public async Task DisconnectAsync()
-        {
-            if (_mqttClient != null && _mqttClient.IsConnected)
-            {
-                try
-                {
-                    await _mqttClient.DisconnectAsync(MqttClientDisconnectOptionsReason.NormalDisconnection);
-                    Log.Information("MQTT client disconnected");
-                }
-                catch (Exception ex)
-                {
-                    Log.Error(ex, "Error disconnecting MQTT client");
-                }
-            }
-        }
+        #endregion Public Methods
+
+        #region Private Methods
 
         private void CheckConnection(object state)
         {
@@ -871,80 +562,467 @@ namespace EliteInfoPanel.Services
             }
         }
 
-        public async Task ClearHomeAssistantConfigs()
+        private Dictionary<Flags2, bool> GetCurrentFlags2States(StatusJson status)
         {
-            _haConfigSent.Clear();
-            Log.Information("Cleared Home Assistant configuration cache - configs will be resent on next publish");
+            var states = new Dictionary<Flags2, bool>();
+
+            // Get ALL flags2 from the enum
+            foreach (Flags2 flag in Enum.GetValues<Flags2>())
+            {
+                if (flag == Flags2.None) continue;
+                states[flag] = (status.Flags2 & (int)flag) != 0;
+            }
+
+            return states;
         }
 
-        public async Task ForceReconfigureHomeAssistant()
+        private Dictionary<Flag, bool> GetCurrentFlagStates(StatusJson status, bool? isDocking = null)
         {
-            if (!_settings.MqttEnabled || _mqttClient == null || !_mqttClient.IsConnected)
+            var states = new Dictionary<Flag, bool>();
+
+            // Get ALL flags from the enum
+            foreach (Flag flag in Enum.GetValues<Flag>())
+            {
+                if (flag == Flag.None) continue;
+
+                // Handle synthetic flags specially
+                if (flag == SyntheticFlags.HudInCombatMode)
+                {
+                    states[flag] = !status.Flags.HasFlag(Flag.HudInAnalysisMode);
+                }
+                else if (flag == SyntheticFlags.Docking)
+                {
+                    // Docking should be true only when actively docking, false when docked or not docking
+                    bool dockingState = isDocking ?? false;
+                    states[flag] = dockingState;
+                    Log.Debug("Synthetic Docking flag: isDocking={IsDocking}, result={Result}", isDocking, dockingState);
+                }
+                else
+                {
+                    states[flag] = status.Flags.HasFlag(flag);
+                }
+            }
+
+            // Add debug logging for key states
+            Log.Debug("Flag states: Docked={Docked}, Docking={Docking}, IsDockingParam={IsDockingParam}",
+                states.GetValueOrDefault(Flag.Docked),
+                states.GetValueOrDefault(SyntheticFlags.Docking),
+                isDocking);
+
+            return states;
+        }
+
+        private string GetDeviceClass(string flagName)
+        {
+            // Be more conservative with device classes to avoid "Connected" states
+            return flagName.ToLower() switch
+            {
+                "overheating" => "problem",
+                "lowfuel" => "problem",
+                "isindanger" => "problem",
+                "beinginterdicted" => "problem",
+                "constructionfailed" => "problem",
+                "constructioncomplete" => null, // Let it default to on/off
+                "supercruise" => "motion",
+                "fsdcharging" => "motion",
+                "fsdjump" => "motion",
+                "glidemode" => "motion",
+                _ => null // Default to no device class for most flags to ensure On/Off display
+            };
+        }
+
+        private bool HasFlagChanges(Dictionary<Flag, bool> currentFlags, Dictionary<Flags2, bool> currentFlags2)
+        {
+            // Check if any primary flags changed
+            foreach (var kvp in currentFlags)
+            {
+                if (!_lastFlagStates.TryGetValue(kvp.Key, out bool lastState) || lastState != kvp.Value)
+                {
+                    Log.Debug("Flag {Flag} changed: {OldState} -> {NewState}", kvp.Key, lastState, kvp.Value);
+                    return true;
+                }
+            }
+
+            // Check if any Flags2 changed
+            foreach (var kvp in currentFlags2)
+            {
+                if (!_lastFlags2States.TryGetValue(kvp.Key, out bool lastState) || lastState != kvp.Value)
+                {
+                    Log.Debug("Flags2 {Flag} changed: {OldState} -> {NewState}", kvp.Key, lastState, kvp.Value);
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private Task OnConnectedAsync(MqttClientConnectedEventArgs arg)
+        {
+            Log.Information("MQTT client connected to {Host}:{Port}", _settings.MqttBrokerHost, _settings.MqttBrokerPort);
+            ConnectionStateChanged?.Invoke(this, true);
+            return Task.CompletedTask;
+        }
+
+        private Task OnDisconnectedAsync(MqttClientDisconnectedEventArgs arg)
+        {
+            Log.Warning("MQTT client disconnected: {Reason}", arg.Reason);
+            ConnectionStateChanged?.Invoke(this, false);
+
+            // Auto-reconnect if not a normal disconnection
+            if (arg.Reason != MqttClientDisconnectReason.NormalDisconnection &&
+                _settings?.MqttEnabled == true && !_cancellationTokenSource.IsCancellationRequested)
+            {
+                _ = Task.Run(async () =>
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(5), _cancellationTokenSource.Token);
+                    if (!_cancellationTokenSource.IsCancellationRequested)
+                    {
+                        try
+                        {
+                            await SetupMqttClientAsync();
+                        }
+                        catch (Exception ex)
+                        {
+                            Log.Error(ex, "Failed to reconnect MQTT client");
+                        }
+                    }
+                });
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private async Task PublishAsync(string topic, string payload, bool retain = false)
+        {
+            if (_mqttClient == null || !_mqttClient.IsConnected)
                 return;
 
             try
             {
-                // Clear the cache so configs get resent
-                _haConfigSent.Clear();
+                var applicationMessage = new MqttApplicationMessageBuilder()
+                    .WithTopic(topic)
+                    .WithPayload(payload)
+                    .WithQualityOfServiceLevel((MqttQualityOfServiceLevel)_settings.MqttQosLevel)
+                    .WithRetainFlag(retain)
+                    .Build();
 
-                // If we have current states, republish them to trigger config resend
-                if (_lastFlagStates.Any() || _lastFlags2States.Any())
-                {
-                    var tasks = new List<Task>();
-
-                    // Republish all flag configs and states using consistent topic structure
-                    foreach (var kvp in _lastFlagStates)
-                    {
-                        string sensor = kvp.Key.ToString().ToLowerInvariant();
-                        string stateTopic = $"{_settings.MqttTopicPrefix}/binary_sensor/{deviceName}/{sensor}/state";
-
-                        await PublishHomeAssistantConfigIfNeeded(kvp.Key.ToString(), stateTopic, "flag");
-                        tasks.Add(PublishAsync(stateTopic, kvp.Value ? "ON" : "OFF", retain: _settings.MqttRetainMessages));
-                    }
-
-                    // Use same topic structure for flags2
-                    foreach (var kvp in _lastFlags2States)
-                    {
-                        string sensor = kvp.Key.ToString().ToLowerInvariant();
-                        string stateTopic = $"{_settings.MqttTopicPrefix}/binary_sensor/{deviceName}/{sensor}/state";
-
-                        await PublishHomeAssistantConfigIfNeeded(kvp.Key.ToString(), stateTopic, "flags2");
-                        tasks.Add(PublishAsync(stateTopic, kvp.Value ? "ON" : "OFF", retain: _settings.MqttRetainMessages));
-                    }
-
-                    await Task.WhenAll(tasks);
-                    Log.Information("Force reconfigured Home Assistant with {FlagCount} flags and {Flags2Count} flags2",
-                        _lastFlagStates.Count, _lastFlags2States.Count);
-                }
+                await _mqttClient.PublishAsync(applicationMessage, _cancellationTokenSource.Token);
+                Log.Debug("Published MQTT message to {Topic}: {Payload}", topic, payload);
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "Error force reconfiguring Home Assistant");
+                Log.Error(ex, "Error publishing MQTT message to topic: {Topic}", topic);
             }
         }
 
-        public void Dispose()
+        private async Task PublishColonizationHomeAssistantDiscovery(long marketId)
         {
-            _cancellationTokenSource?.Cancel();
-            _reconnectTimer?.Dispose();
+            // Create Home Assistant discovery configs for this depot
+            var baseConfig = new
+            {
+                device = new
+                {
+                    identifiers = new[] { $"eliteinfopanel_colonisation_{marketId}" },
+                    name = $"Colonisation Depot {marketId}",
+                    manufacturer = "Frontier Developments",
+                    model = "Elite Dangerous Colonisation Depot",
+                    sw_version = "1.0"
+                },
+                availability = new
+                {
+                    topic = $"{_settings.MqttTopicPrefix}/status",
+                    payload_available = "online",
+                    payload_not_available = "offline"
+                }
+            };
 
+            // Progress sensor
+            var progressConfig = new
+            {
+                name = $"Colonisation Progress {marketId}",
+                state_topic = $"{_settings.MqttTopicPrefix}/colonisation/depots/{marketId}",
+                value_template = "{{ value_json.ConstructionProgress | float * 100 | round(1) }}",
+                unit_of_measurement = "%",
+                icon = "mdi:progress-clock",
+                unique_id = $"eliteinfopanel_colonisation_progress_{marketId}",
+                device = baseConfig.device
+            };
+
+            // Resources completed sensor
+            var resourcesConfig = new
+            {
+                name = $"Colonisation Resources {marketId}",
+                state_topic = $"{_settings.MqttTopicPrefix}/colonisation/depots/{marketId}",
+                value_template = "{{ value_json.ResourcesRequired | selectattr('IsComplete', 'equalto', true) | list | length }}",
+                unit_of_measurement = "resources",
+                icon = "mdi:package-check",
+                unique_id = $"eliteinfopanel_colonisation_resources_{marketId}",
+                device = baseConfig.device,
+                json_attributes_topic = $"{_settings.MqttTopicPrefix}/colonisation/depots/{marketId}",
+                json_attributes_template = "{{ {'total_resources': value_json.ResourcesRequired | length, 'resources': value_json.ResourcesRequired} | tojson }}"
+            };
+
+            // Status sensor (active/complete/failed)
+            var statusConfig = new
+            {
+                name = $"Colonisation Status {marketId}",
+                state_topic = $"{_settings.MqttTopicPrefix}/colonisation/depots/{marketId}",
+                value_template = "{% if value_json.ConstructionComplete %}complete{% elif value_json.ConstructionFailed %}failed{% else %}active{% endif %}",
+                icon = "mdi:home-city",
+                unique_id = $"eliteinfopanel_colonisation_status_{marketId}",
+                device = baseConfig.device
+            };
+
+            // Publish discovery configs
+            await PublishAsync($"homeassistant/sensor/eliteinfopanel_colonisation_progress_{marketId}/config",
+                JsonSerializer.Serialize(progressConfig), retain: true);
+
+            await PublishAsync($"homeassistant/sensor/eliteinfopanel_colonisation_resources_{marketId}/config",
+                JsonSerializer.Serialize(resourcesConfig), retain: true);
+
+            await PublishAsync($"homeassistant/sensor/eliteinfopanel_colonisation_status_{marketId}/config",
+                JsonSerializer.Serialize(statusConfig), retain: true);
+        }
+
+        private async Task PublishCombinedStatusAsync(StatusJson status, Dictionary<Flag, bool> flags, Dictionary<Flags2, bool> flags2)
+        {
+            var topic = $"{_settings.MqttTopicPrefix}/status";
+
+            // Enhanced combined status with metadata
+            var payload = JsonSerializer.Serialize(new
+            {
+                timestamp = DateTime.UtcNow.ToString("O"),
+                flags = flags.ToDictionary(
+                    f => f.Key.ToString().ToLower(),
+                    f => new
+                    {
+                        active = f.Value,
+                        metadata = FlagVisualHelper.TryGetMetadata(f.Key, out var meta) ? new
+                        {
+                            icon = meta.Icon,
+                            tooltip = meta.Tooltip,
+                            color = meta.Color.ToString()
+                        } : null
+                    }
+                ),
+                flags2 = flags2.ToDictionary(
+                    f => f.Key.ToString().ToLower(),
+                    f => new
+                    {
+                        active = f.Value,
+                        metadata = Flags2VisualHelper.TryGetMetadata(f.Key, out var meta) ? new
+                        {
+                            icon = meta.Icon,
+                            tooltip = meta.Tooltip,
+                            color = meta.Color.ToString()
+                        } : null
+                    }
+                ),
+                raw_flags = (uint)status.Flags,
+                raw_flags2 = status.Flags2,
+                fuel = status.Fuel?.FuelMain ?? 0,
+                balance = status.Balance,
+                on_foot = status.OnFoot,
+                active_flags_count = flags.Count(f => f.Value),
+                active_flags2_count = flags2.Count(f => f.Value),
+                total_flags_count = flags.Count,
+                total_flags2_count = flags2.Count
+            }, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+
+            await PublishAsync(topic, payload, retain: _settings.MqttRetainMessages);
+        }
+
+        private async Task PublishHomeAssistantCommanderConfigsIfNeeded()
+        {
+            string baseTopic = $"{_settings.MqttTopicPrefix}/commander";
+
+            var configs = new List<(string id, string name, string valueTemplate)>
+    {
+        ("commander", "Commander", "{{ value_json.commander }}"),
+        ("system", "System", "{{ value_json.system }}"),
+        ("ship", "Ship", "{{ value_json.ship }}"),
+        ("credits", "Credits", "{{ value_json.credits }}"),
+        ("fuel", "Fuel", "{{ value_json.fuel }}"),
+        ("fuelreserve", "Fuel Reserve", "{{ value_json.fuelreserve }}")
+    };
+
+            foreach (var (id, name, valueTemplate) in configs)
+            {
+                string configTopic = $"homeassistant/sensor/eliteinfopanel_{id}/config";
+                if (_haConfigSent.Contains(configTopic)) continue;
+
+                var configPayload = new
+                {
+                    name,
+                    state_topic = baseTopic,
+                    unique_id = $"eliteinfopanel_{id}",
+                    object_id = id,
+                    value_template = valueTemplate,
+                    json_attributes_topic = baseTopic,  // Optional, if you want other fields as attributes
+                    device = new
+                    {
+                        identifiers = new[] { "eliteinfopanel" },
+                        name = "Elite Info Panel",
+                        manufacturer = "Frontier Developments",
+                        model = "Elite Dangerous Game State",
+                        sw_version = "1.0"
+                    }
+                };
+
+                string configJson = JsonSerializer.Serialize(configPayload);
+                await PublishAsync(configTopic, configJson, retain: true);
+                _haConfigSent.Add(configTopic);
+
+                Log.Debug("Published Home Assistant config for {Name} sensor", name);
+            }
+        }
+
+        private async Task PublishHomeAssistantConfigIfNeeded(string flagName, string stateTopic, string flagType = "flag")
+        {
+            if (!_settings.MqttEnabled || _mqttClient == null || !_mqttClient.IsConnected)
+                return;
+
+            string sensor = flagName.ToLowerInvariant();
+            // Change the config topic to not include the device name prefix
+            string configTopic = $"homeassistant/binary_sensor/eliteinfopanel/{sensor}/config";
+
+            if (_haConfigSent.Contains(configTopic)) return;
+
+            // Get metadata for this flag
+            string icon = "mdi:help";
+            string friendlyName = flagName;
+
+            if (flagType == "flag" && Enum.TryParse<Flag>(flagName, true, out var flag))
+            {
+                if (FlagVisualHelper.TryGetMetadata(flag, out var metadata))
+                {
+                    icon = $"mdi:{metadata.Icon.ToLowerInvariant()}";
+                    friendlyName = metadata.Tooltip ?? flagName;
+                }
+            }
+            else if (flagType == "flags2" && Enum.TryParse<Flags2>(flagName, true, out var flags2))
+            {
+                if (Flags2VisualHelper.TryGetMetadata(flags2, out var metadata))
+                {
+                    icon = $"mdi:{metadata.Icon.ToLowerInvariant()}";
+                    friendlyName = metadata.Tooltip ?? flagName;
+                }
+            }
+
+            var configPayload = new
+            {
+                name = friendlyName, // Use just the friendly name without device prefix
+                state_topic = stateTopic,
+                unique_id = $"eliteinfopanel_{sensor}", // Keep unique ID with prefix for uniqueness
+                object_id = sensor, // Add this to control the entity ID
+                icon = icon,
+                payload_on = "ON",
+                payload_off = "OFF",
+                device_class = GetDeviceClass(flagName),
+                device = new
+                {
+                    identifiers = new[] { "eliteinfopanel" }, // Consistent device identifier
+                    name = "Elite Info Panel", // More readable device name
+                    manufacturer = "Frontier Developments",
+                    model = "Elite Dangerous Game State",
+                    sw_version = "1.0"
+                }
+            };
+
+            string configJson = JsonSerializer.Serialize(configPayload);
+            await PublishAsync(configTopic, configJson, retain: true);
+            _haConfigSent.Add(configTopic);
+
+            Log.Debug("Published Home Assistant config for {FlagType} {Flag}: {FriendlyName}", flagType, flagName, friendlyName);
+        }
+
+        private async Task PublishIndividualFlagsAsync(Dictionary<Flag, bool> flags, Dictionary<Flags2, bool> flags2)
+        {
+            var tasks = new List<Task>();
+
+            // Publish ALL primary flags as Home Assistant binary sensors
+            foreach (var kvp in flags)
+            {
+                string sensor = kvp.Key.ToString().ToLowerInvariant();
+                // Use consistent topic structure for all sensors
+                string stateTopic = $"{_settings.MqttTopicPrefix}/binary_sensor/{deviceName}/{sensor}/state";
+                string payload = kvp.Value ? "ON" : "OFF";
+
+                // Send Home Assistant config first
+                await PublishHomeAssistantConfigIfNeeded(kvp.Key.ToString(), stateTopic, "flag");
+
+                // Then send the state
+                tasks.Add(PublishAsync(stateTopic, payload, retain: _settings.MqttRetainMessages));
+            }
+
+            // Publish ALL Flags2 as Home Assistant binary sensors using the same topic structure
+            foreach (var kvp in flags2)
+            {
+                string sensor = kvp.Key.ToString().ToLowerInvariant();
+                // Use same topic structure as primary flags to keep under one device
+                string stateTopic = $"{_settings.MqttTopicPrefix}/binary_sensor/{deviceName}/{sensor}/state";
+                string payload = kvp.Value ? "ON" : "OFF";
+
+                // Send Home Assistant config first
+                await PublishHomeAssistantConfigIfNeeded(kvp.Key.ToString(), stateTopic, "flags2");
+
+                // Then send the state
+                tasks.Add(PublishAsync(stateTopic, payload, retain: _settings.MqttRetainMessages));
+            }
+
+            await Task.WhenAll(tasks);
+        }
+
+        private async Task SetupMqttClientAsync()
+        {
+            // Dispose existing client if it exists
             if (_mqttClient != null)
             {
-                try
+                if (_mqttClient.IsConnected)
                 {
-                    if (_mqttClient.IsConnected)
-                    {
-                        _mqttClient.DisconnectAsync(MqttClientDisconnectOptionsReason.NormalDisconnection).Wait(5000);
-                    }
-                    _mqttClient.Dispose();
+                    await _mqttClient.DisconnectAsync(MqttClientDisconnectOptionsReason.NormalDisconnection);
                 }
-                catch (Exception ex)
-                {
-                    Log.Error(ex, "Error disposing MQTT client");
-                }
+                _mqttClient.Dispose();
             }
 
-            _cancellationTokenSource?.Dispose();
+            var factory = new MqttClientFactory();
+            _mqttClient = factory.CreateMqttClient();
+
+            // Create client options using MQTTnet 5 API
+            var clientOptionsBuilder = new MqttClientOptionsBuilder()
+                .WithClientId(_settings.MqttClientId)
+                .WithTcpServer(_settings.MqttBrokerHost, _settings.MqttBrokerPort)
+                .WithCleanSession(true)
+                .WithProtocolVersion(MqttProtocolVersion.V500);
+
+            // Add credentials if provided
+            if (!string.IsNullOrEmpty(_settings.MqttUsername))
+            {
+                clientOptionsBuilder.WithCredentials(_settings.MqttUsername, _settings.MqttPassword);
+            }
+
+            // Add TLS if enabled
+            if (_settings.MqttUseTls)
+            {
+                clientOptionsBuilder.WithTlsOptions(o =>
+                {
+                    o.UseTls();
+                    o.WithAllowUntrustedCertificates(false);
+                    o.WithIgnoreCertificateChainErrors(false);
+                    o.WithIgnoreCertificateRevocationErrors(false);
+                });
+            }
+
+            var clientOptions = clientOptionsBuilder.Build();
+
+            // Set up event handlers
+            _mqttClient.ConnectedAsync += OnConnectedAsync;
+            _mqttClient.DisconnectedAsync += OnDisconnectedAsync;
+
+            // Connect the client
+            await _mqttClient.ConnectAsync(clientOptions, _cancellationTokenSource.Token);
         }
+
+        #endregion Private Methods
     }
 }

--- a/ViewModels/ColinizationViewModel.cs
+++ b/ViewModels/ColinizationViewModel.cs
@@ -54,7 +54,7 @@ namespace EliteInfoPanel.ViewModels
             ForceRefreshCommand = new RelayCommand(_ => ForceRefresh());
             OpenInNewWindowCommand = new RelayCommand(_ => OpenInNewWindow());
             ExportToCsvCommand = new RelayCommand(_ => ExportToCsv());
-
+            RemoveCurrentDepotCommand = new RelayCommand(_ => RemoveCurrentDepot());
             // Subscribe to property changes
             _gameState.PropertyChanged += GameState_PropertyChanged;
 
@@ -73,7 +73,7 @@ namespace EliteInfoPanel.ViewModels
 
         #region Public Properties
         public ObservableCollection<ColonizationDepotInfo> AvailableDepots { get; } = new ObservableCollection<ColonizationDepotInfo>();
-
+        public RelayCommand RemoveCurrentDepotCommand { get; }
         public ColonizationDepotInfo SelectedDepot
         {
             get => AvailableDepots.FirstOrDefault(d => d.MarketID == _selectedMarketId);
@@ -209,7 +209,73 @@ namespace EliteInfoPanel.ViewModels
         #endregion Public Properties
 
         #region Private Methods
+        private async void RemoveCurrentDepot()
+        {
+            try
+            {
+                if (!_selectedMarketId.HasValue)
+                {
+                    ShowToast("No colonization depot selected");
+                    return;
+                }
 
+                var selectedDepot = SelectedDepot;
+                if (selectedDepot == null)
+                {
+                    ShowToast("No colonization depot selected");
+                    return;
+                }
+
+                // Show confirmation dialog
+                var result = MessageBox.Show(
+                    $"Are you sure you want to remove the colonization depot at {selectedDepot.SystemName}?\n\n" +
+                    $"Progress: {selectedDepot.Progress:P0}\n" +
+                    $"Resources: {selectedDepot.CompletedCount}/{selectedDepot.ResourceCount}",
+                    "Remove Colonization Depot",
+                    MessageBoxButton.YesNo,
+                    MessageBoxImage.Question);
+
+                if (result != MessageBoxResult.Yes)
+                {
+                    return;
+                }
+
+                Log.Information("User confirmed removal of depot {MarketID}", _selectedMarketId.Value);
+
+                // Remove from GameState
+                _gameState.RemoveColonizationDepot(_selectedMarketId.Value);
+
+                // Publish MQTT deletion
+                try
+                {
+                    await MqttService.Instance.PublishColonizationDepotDeletedAsync(_selectedMarketId.Value);
+                }
+                catch (Exception ex)
+                {
+                    Log.Warning(ex, "Could not publish MQTT deletion");
+                }
+
+                ShowToast("Colonization depot removed");
+
+                // Refresh the depot list
+                RefreshAvailableDepots();
+
+                // Force update the UI
+                UpdateColonizationDataInternal();
+
+                // Check if card should hide
+                if (!AvailableDepots.Any())
+                {
+                    Log.Information("No colonization depots remain - hiding card");
+                    SetContextVisibility(false);
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Error removing colonization depot");
+                ShowToast("Failed to remove depot: " + ex.Message);
+            }
+        }
         private void EnsureWindowIsVisible(Window window, AppSettings settings)
         {
             // Get screen information
@@ -588,9 +654,17 @@ namespace EliteInfoPanel.ViewModels
 
                 var colonizationData = _gameState.CurrentColonization;
 
-                if (colonizationData == null)
+                if (!_gameState.GetActiveColonizationDepots().Any())
                 {
-                    Log.Information("UpdateColonizationDataInternal: No colonization data available");
+                    Log.Information("UpdateColonizationDataInternal: No active depots - hiding card");
+                    SetContextVisibility(false);
+                    Items.Clear();
+                    return;
+                }
+
+                if (colonizationData == null || colonizationData.LastUpdated == DateTime.MinValue)
+                {
+                    Log.Information("UpdateColonizationDataInternal: No colonization data available or data is uninitialized");
                     SetContextVisibility(false);
                     Items.Clear();
                     return;
@@ -632,7 +706,8 @@ namespace EliteInfoPanel.ViewModels
 
                 if (colonizationData.ResourcesRequired == null || !colonizationData.ResourcesRequired.Any())
                 {
-                    Log.Warning("UpdateColonizationDataInternal: No resources found in colonization data");
+                    Log.Warning("UpdateColonizationDataInternal: No resources found in colonization data - hiding card");
+                    SetContextVisibility(false);
                     return;
                 }
 
@@ -714,6 +789,13 @@ namespace EliteInfoPanel.ViewModels
                 }
 
                 Log.Information("UpdateColonizationDataInternal: Update complete - Added {Count} resource items", Items.Count);
+
+                // Hide the card if there are no items to display
+                if (Items.Count == 0)
+                {
+                    Log.Information("UpdateColonizationDataInternal: No items to display after filtering - hiding card");
+                    SetContextVisibility(false);
+                }
             }
             catch (Exception ex)
             {

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -149,13 +149,18 @@ namespace EliteInfoPanel.ViewModels
             // Apply user preferences AFTER everything else
             ApplyUserCardPreferences();
 
-            // IMPORTANT: Add this explicit check for colonization data
+            // IMPORTANT: Add this explicit check for valid colonization data
             // It needs to happen AFTER ApplyUserCardPreferences to override it if needed
-            if (_gameState.CurrentColonization != null)
+            bool hasColonizationData = _gameState.CurrentColonization != null &&
+                                       _gameState.CurrentColonization.LastUpdated != DateTime.MinValue &&
+                                       _gameState.CurrentColonization.ResourcesRequired?.Count > 0 &&
+                                       !_gameState.CurrentColonization.ConstructionComplete &&
+                                       !_gameState.CurrentColonization.ConstructionFailed;
+            
+            if (hasColonizationData)
             {
-                Log.Information("MainViewModel: Found colonization data after initialization - making card visible");
+                Log.Information("MainViewModel: Found valid colonization data after initialization - updating card visibility");
                 UpdateColonizationCardVisibility();
-
             }
             EventAggregator.Instance.Subscribe<CardVisibilityChangedEvent>(OnCardVisibilityChanged);
             EventAggregator.Instance.Subscribe<LayoutRefreshRequestEvent>(OnLayoutRefreshRequested);
@@ -333,11 +338,20 @@ namespace EliteInfoPanel.ViewModels
             FlagsCard.SetContextVisibility(true); // CHANGED: Use SetContextVisibility
             FlagsCard.IsUserEnabled = settings.ShowFlags; // ADDED: Set user preference directly
 
-            // Colonization card - evaluated once
-           
-            ColonizationCard.SetContextVisibility(true); // Always set the context to true
-            ColonizationCard.IsUserEnabled = settings.ShowColonisation; // Let user setting control visibility
-                                                                        // Fleet Carrier Cargo card (user controlled only)
+            // Colonization card - check if there's actual data
+            bool hasColonizationData = _gameState.CurrentColonization != null &&
+                                       _gameState.CurrentColonization.LastUpdated != DateTime.MinValue &&
+                                       _gameState.CurrentColonization.ResourcesRequired?.Count > 0 &&
+                                       !_gameState.CurrentColonization.ConstructionComplete &&
+                                       !_gameState.CurrentColonization.ConstructionFailed;
+            
+            ColonizationCard.SetContextVisibility(hasColonizationData);
+            ColonizationCard.IsUserEnabled = settings.ShowColonisation;
+            
+            Log.Debug("Colonization card visibility: HasData={HasData}, ContextVisible={Context}, UserEnabled={User}",
+                hasColonizationData, hasColonizationData, settings.ShowColonisation);
+            
+            // Fleet Carrier Cargo card (user controlled only)
             FleetCarrierCard.SetContextVisibility(true); // Always context-visible
             FleetCarrierCard.IsUserEnabled = settings.ShowFleetCarrierCargoCard;  // Respect user setting
             Log.Information("FleetCarrierCard.SetContextVisibility({Visible}), IsUserEnabled: {Enabled}",
@@ -449,33 +463,25 @@ namespace EliteInfoPanel.ViewModels
                 var settings = SettingsManager.Load();
                 bool userEnabled = settings.ShowColonisation;
 
-                // IMPORTANT: Check if we have actual data, regardless of what the status says
+                // Check if we have valid, active colonization data
                 bool hasData = _gameState.CurrentColonization != null &&
-                              _gameState.CurrentColonization.ResourcesRequired?.Count > 0;
+                              _gameState.CurrentColonization.LastUpdated != DateTime.MinValue &&
+                              _gameState.CurrentColonization.ResourcesRequired?.Count > 0 &&
+                              !_gameState.CurrentColonization.ConstructionComplete &&
+                              !_gameState.CurrentColonization.ConstructionFailed;
 
                 Log.Information("Updating ColonizationCard visibility: UserEnabled={UserEnabled}, HasData={HasData}",
                               userEnabled, hasData);
 
-                // Set context visibility to true if we have data (override the usual game state logic)
-                if (hasData)
-                {
-                    // Always set context visibility to true if we have data
-                    ColonizationCard.SetContextVisibility(true);
-                    ColonizationCard.IsUserEnabled = userEnabled;
+                // Set context visibility based on whether we have valid data
+                ColonizationCard.SetContextVisibility(hasData);
+                ColonizationCard.IsUserEnabled = userEnabled;
 
-                    Log.Information("ColonizationCard should be visible: HasData=true, UserEnabled={UserEnabled}",
-                                  userEnabled);
+                Log.Information("ColonizationCard context visibility set to: {HasData}, UserEnabled={UserEnabled}",
+                              hasData, userEnabled);
 
-                    // Force a layout refresh
-                    RefreshLayout(true);
-                }
-                else if (ColonizationCard.IsVisible)
-                {
-                    // Only hide if we don't have data and it's currently visible
-                    ColonizationCard.SetContextVisibility(false);
-                    Log.Information("ColonizationCard hidden due to no data");
-                    RefreshLayout(true);
-                }
+                // Force a layout refresh if visibility changed
+                RefreshLayout(true);
             }
             catch (Exception ex)
             {
@@ -486,8 +492,10 @@ namespace EliteInfoPanel.ViewModels
         {
             try
             {
-                // Check if the colonization data exists and is active
+                // Check if we have valid, active colonization data
                 bool hasActiveColonization = _gameState.CurrentColonization != null &&
+                                            _gameState.CurrentColonization.LastUpdated != DateTime.MinValue &&
+                                            _gameState.CurrentColonization.ResourcesRequired?.Count > 0 &&
                                             !_gameState.CurrentColonization.ConstructionComplete &&
                                             !_gameState.CurrentColonization.ConstructionFailed;
 
@@ -498,7 +506,6 @@ namespace EliteInfoPanel.ViewModels
                 Log.Information("MainViewModel: Updating colonization data - HasData={HasData}, UserEnabled={UserEnabled}",
                     hasActiveColonization, userEnabled);
 
-                // FIXED: Instead of directly setting IsVisible, use the proper methods
                 // Set context visibility based on data availability
                 ColonizationCard.SetContextVisibility(hasActiveColonization);
 
@@ -508,13 +515,8 @@ namespace EliteInfoPanel.ViewModels
                 // The final visibility will be determined by CardViewModel.UpdateIsVisible()
                 // which combines both context visibility and user preference
 
-                // Check if we need to refresh the layout (this won't change)
-                bool shouldBeVisible = hasActiveColonization && userEnabled;
-                if (shouldBeVisible)
-                {
-                    // Force layout refresh to ensure colonization card is displayed
-                    RefreshLayout(true);
-                }
+                // Refresh layout if needed
+                RefreshLayout(true);
             }
             catch (Exception ex)
             {
@@ -771,12 +773,19 @@ namespace EliteInfoPanel.ViewModels
                 card.SetContextVisibility(false);
             }
 
-            if (_gameState.CurrentColonization != null)
+            // Check for valid colonization data
+            bool hasColonizationData = _gameState.CurrentColonization != null &&
+                                       _gameState.CurrentColonization.LastUpdated != DateTime.MinValue &&
+                                       _gameState.CurrentColonization.ResourcesRequired?.Count > 0 &&
+                                       !_gameState.CurrentColonization.ConstructionComplete &&
+                                       !_gameState.CurrentColonization.ConstructionFailed;
+            
+            if (hasColonizationData)
             {
                 var settings = SettingsManager.Load();
-                Log.Information("Colonization data found during initial visibility setup");
+                Log.Information("Valid colonization data found during initial visibility setup");
 
-                // FIXED: Set both context visibility and user preference correctly
+                // Set both context visibility and user preference correctly
                 ColonizationCard.SetContextVisibility(true);
                 ColonizationCard.IsUserEnabled = settings.ShowColonisation;
             }


### PR DESCRIPTION
- Added "Remove Colonization Depot" button to the UI.
- Implemented `RemoveColonizationDepot` in `GameStateService`.
- Automatically skip completed/failed depots during data load.
- Added MQTT integration for depot deletion and summary publishing.
- Refactored `MqttService` for better organization and connection handling.
- Enhanced colonization card visibility and initialization logic.
- Added confirmation dialog for depot removal with user feedback.
- Improved error handling and logging for depot removal and updates.
- Updated colonization data filtering and card refresh logic.
- Ensured consistent handling of user preferences and card visibility.